### PR TITLE
Validate Number of Emojis | FindEmojis

### DIFF
--- a/src/FindEmoji.js
+++ b/src/FindEmoji.js
@@ -21,6 +21,7 @@ module.exports = class FindEmoji extends events {
     if (!options.timeoutTime) options.timeoutTime = 60000;
     if (!options.hideEmojiTime) options.hideEmojiTime = 5000;
     if (!options.buttonStyle) options.buttonStyle = 'PRIMARY';
+    if (options.emojis && option.emojis.length < 8) throw new TypeError('LESS_EMOJIS: The number of emojis must be 8 or greater.');
     if (!options.emojis) options.emojis = ['🍉', '🍇', '🍊', '🍋', '🥭', '🍎', '🍏', '🥝', '🥥', '🍓', '🍒'];
 
     if (!options.winMessage) options.winMessage = 'You won! You selected the correct emoji. {emoji}';


### PR DESCRIPTION
Code doesn't work if number of emojis is less than 8.

## Changes
- Added a validation check to ensure that the number of emojis is 8 or greater.

## Screenshots
*No screenshots available for this change.*

## Status

- [x] These changes have been tested and formatted properly.
- [ ] These changes also include the change in documentation accordingly.
- [ ] This PR introduces some Breaking changes
