### PR TITLE
Fix faulty connect4 button disabling behavior

### DIFF
--- a/src/Connect4.js
+++ b/src/Connect4.js
@@ -150,8 +150,8 @@ module.exports = class Connect4 extends approve {
 
 
       if (block.y === 0) {
-        const components = msg.components[(column > 3) ? 1 : 0].components;
-        if (column > 3) components[column % 4] = ButtonBuilder.from(components[column % 4]).setDisabled(true);
+        const components = msg.components[(column > 4) ? 1 : 0].components;
+        if (column > 4) components[column % 5] = ButtonBuilder.from(components[column % 5]).setDisabled(true);
         else components[column] = ButtonBuilder.from(components[column]).setDisabled(true);
       }
 


### PR DESCRIPTION
## Changes
This PR fixes an issue for Connect4 where IF the 5th Column is filled, the 6th Column Button will be disabled instead of the 5th Column Button. 

Please refer to the screenshots below.

## Screenshots

Prior to the fix: 
![image](https://github.com/user-attachments/assets/bc6a122b-3f45-44d2-b61e-2e1bc6369ac7)


After the fix:
![image](https://github.com/user-attachments/assets/fd6ed8fb-f280-4b70-ba02-0cc3205f4b4f)


## Status

- [x] These changes have been tested and formatted properly.
- [x] These changes also include the change in documentation accordingly.
- [x] This PR introduces some Breaking changes
